### PR TITLE
Add support for CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ Note the hash keys will be converted to upper case.
 
 You can refer to Thumbor wiki for configuration options https://github.com/globocom/thumbor/wiki/Configuration 
 
+#### `additional_packages`
+
+[Array]
+*Default: A OS-specific list of packages*
+
+Specifies a list of additional packages that are required for thumbor or any of it's dependencies.
+
 ## Reference
 
 ### Classes

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,23 +20,24 @@
 # @param ensure_group [Boolean] If we control the installation of the group, default true
 # @param group [String] Name of the group to install (optional) and under which we run the thumbor service, default thumbor
 # @param extensions Variant[Array[String],String] Extentions to install in thumbor virtual environment, default []
+# @param additional_packages [Array] Specifies a list of additional packages that are required for thumbor or any of it's dependencies.
 #
 #
 class thumbor (
   Hash                                $config,
-  Enum['present', 'absent']           $ensure           = $thumbor::params::ensure,
-  Optional[String]                    $security_key     = $thumbor::params::security_key,
-  String                              $listen           = $thumbor::params::listen,
-  Variant[Array[String],String]       $ports            = $thumbor::params::ports,
-  Optional[String]                    $virtualenv_path  = $thumbor::params::virtualenv_path,
-  String                              $package_name     = $thumbor::params::package_name,
-  Enum['present', 'absent', 'latest'] $package_ensure   = $thumbor::params::package_ensure,
-  Variant[Boolean, String]            $pip_proxyserver  = $thumbor::params::pip_proxyserver,
-  Boolean                             $ensure_user      = $thumbor::params::ensure_user,
-  String                              $user             = $thumbor::params::user,
-  Boolean                             $ensure_group     = $thumbor::params::ensure_group,
-  String                              $group            = $thumbor::params::group,
-  Variant[Array[String],String]       $extentions       = $thumbor::params::extentions,
+  Enum['present', 'absent']           $ensure              = $thumbor::params::ensure,
+  Optional[String]                    $security_key        = $thumbor::params::security_key,
+  String                              $listen              = $thumbor::params::listen,
+  Variant[Array[String],String]       $ports               = $thumbor::params::ports,
+  Optional[String]                    $virtualenv_path     = $thumbor::params::virtualenv_path,
+  String                              $package_name        = $thumbor::params::package_name,
+  Enum['present', 'absent', 'latest'] $package_ensure      = $thumbor::params::package_ensure,
+  Variant[Boolean, String]            $pip_proxyserver     = $thumbor::params::pip_proxyserver,
+  Boolean                             $ensure_user         = $thumbor::params::ensure_user,
+  String                              $user                = $thumbor::params::user,
+  Boolean                             $ensure_group        = $thumbor::params::ensure_group,
+  String                              $group               = $thumbor::params::group,
+  Variant[Array[String],String]       $extentions          = $thumbor::params::extentions,
   Array                               $additional_packages = $thumbor::params::additional_packages,
 ) inherits thumbor::params
 {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class thumbor (
   Boolean                             $ensure_group     = $thumbor::params::ensure_group,
   String                              $group            = $thumbor::params::group,
   Variant[Array[String],String]       $extentions       = $thumbor::params::extentions,
+  Array                               $additional_packages = $thumbor::params::additional_packages,
 ) inherits thumbor::params
 {
   $apppath = $virtualenv_path ? {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,9 +35,9 @@ class thumbor::install
 
   class { 'python' :
     version    => 'system',
-    pip        => true,
-    dev        => true,
-    virtualenv => true,
+    pip        => 'present',
+    dev        => 'present',
+    virtualenv => 'present',
     require    => Anchor['thumbor::install::begin'],
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -58,7 +58,7 @@ class thumbor::install
     before  => Anchor['thumbor::install::end'],
   }
 
-  ensure_packages(['libcurl4-openssl-dev', 'build-essential', 'libssl-dev', 'libjpeg-turbo-progs', 'gifsicle'])
+  ensure_packages($thumbor::additional_packages)
 
   $venv = $thumbor::virtualenv_path ? {
     undef   => 'system',
@@ -69,17 +69,15 @@ class thumbor::install
     ensure     => $thumbor::package_ensure,
     virtualenv => $venv,
     proxy      => $thumbor::pip_proxyserver,
-    require    => [ Package[['libcurl4-openssl-dev', 'build-essential', 'libssl-dev']], Anchor['thumbor::install::virtualenv'] ],
+    require    => [ Package[$thumbor::additional_packages], Anchor['thumbor::install::virtualenv'] ],
     before     => Anchor['thumbor::install::end'],
   }
-
-  ensure_packages(['libglib2.0-0', 'libsm6', 'libxrender1', 'libxext6'])
 
   python::pip { 'opencv-python':
     ensure     => $thumbor::package_ensure,
     virtualenv => $venv,
     proxy      => $thumbor::pip_proxyserver,
-    require    => [ Package[['libglib2.0-0', 'libsm6', 'libxrender1', 'libxext6']], Anchor['thumbor::install::virtualenv'] ],
+    require    => [ Package[$thumbor::additional_packages], Anchor['thumbor::install::virtualenv'] ],
     before     => Anchor['thumbor::install::end'],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,4 +17,35 @@ class thumbor::params
   Hash                          $default_options  = {},
 )
 {
+  case $facts['os']['family'] {
+    'Debian': {
+      $additional_packages = ['build-essential',
+                              'gifsicle',
+                              'libcurl4-openssl-dev',
+                              'libglib2.0-0',
+                              'libjpeg-turbo-progs',
+                              'libsm6',
+                              'libssl-dev',
+                              'libxext6',
+                              'libxrender1']
+    }
+    'RedHat': {
+      $additional_packages = ['automake',
+                              'gcc',
+                              'gcc-c++',
+                              'gifsicle',
+                              'glib2',
+                              'libcurl-devel',
+                              'libjpeg-turbo',
+                              'libSM',
+                              'libXext',
+                              'libXrender',
+                              'make',
+                              'openssl-devel',
+                              'openssl-libs']
+    }
+    default: {
+      fail("Operating system ${facts['os']['family']} is not currently supported in module ${module_name}")
+    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
       "version_requirement": ">= 1.0.0"
     },
     {
-      "name": "stankevich/python",
+      "name": "puppet/python",
       "version_requirement": ">= 1.12.0 < 3.0.0"
     }
   ],


### PR DESCRIPTION
* Add support for CentOS (introduced new parameter `$additional_packages`)
* Fix compatibility with new versions of puppet/python
* Fix dependency: stankevich/python was moved to voxpupuli