### PR TITLE
Improvements related to puppet/python

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@
 # @param virtualenv_path Optional[String] If we use virtualenv (false if undef) and what path we use as base, default undef
 # @param package_name [String] Package name of the thumbor application as found in pip, default thumbor
 # @param package_ensure Enum['present', 'absent', 'latest'] Control the ensure on pip, default $ensure ('present')
-# @param pip_proxyserver Variant[Boolean, String] The full url (including credentials) to a proxy server or false to not use one at all, default false
+# @param pip_proxyserver Optional[String] The full url (including credentials) to a proxy server or undef to not use one at all, default undef
 # @param ensure_user [Boolean] If we control the installation of the user, default true
 # @param user [String] Name of the user to install (optional) and under which we run the thumbor service, default thumbor
 # @param ensure_group [Boolean] If we control the installation of the group, default true
@@ -33,7 +33,7 @@ class thumbor (
   Optional[String]                    $virtualenv_path     = $thumbor::params::virtualenv_path,
   String                              $package_name        = $thumbor::params::package_name,
   Enum['present', 'absent', 'latest'] $package_ensure      = $thumbor::params::package_ensure,
-  Variant[Boolean, String]            $pip_proxyserver     = $thumbor::params::pip_proxyserver,
+  Optional[String]                    $pip_proxyserver     = $thumbor::params::pip_proxyserver,
   Boolean                             $ensure_user         = $thumbor::params::ensure_user,
   String                              $user                = $thumbor::params::user,
   Boolean                             $ensure_group        = $thumbor::params::ensure_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@
 # @param group [String] Name of the group to install (optional) and under which we run the thumbor service, default thumbor
 # @param extensions Variant[Array[String],String] Extentions to install in thumbor virtual environment, default []
 # @param additional_packages [Array] Specifies a list of additional packages that are required for thumbor or any of it's dependencies.
+# @param manage_python [Boolean] If we control the installation of Python, default true
 #
 #
 class thumbor (
@@ -39,6 +40,7 @@ class thumbor (
   String                              $group               = $thumbor::params::group,
   Variant[Array[String],String]       $extentions          = $thumbor::params::extentions,
   Array                               $additional_packages = $thumbor::params::additional_packages,
+  Boolean                             $manage_python       = $thumbor::params::manage_python,
 ) inherits thumbor::params
 {
   $apppath = $virtualenv_path ? {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -48,7 +48,7 @@ class thumbor::install
     python::virtualenv { $thumbor::virtualenv_path:
       ensure  => $thumbor::ensure,
       version => 'system',
-      proxy   => $thumbor::proxy,
+      proxy   => $thumbor::pip_proxyserver,
       owner   => $thumbor::user,
       group   => $thumbor::group,
       require => [ Class['python'] ],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,12 +33,14 @@ class thumbor::install
     }
   }
 
-  class { 'python' :
-    version    => 'system',
-    pip        => 'present',
-    dev        => 'present',
-    virtualenv => 'present',
-    require    => Anchor['thumbor::install::begin'],
+  if $thumbor::manage_python {
+    class { 'python' :
+      version    => 'system',
+      pip        => 'present',
+      dev        => 'present',
+      virtualenv => 'present',
+      require    => Anchor['thumbor::install::begin'],
+    }
   }
 
   if $thumbor::virtualenv_path {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class thumbor::params
   String                        $group            = 'thumbor',
   Variant[Array[String],String] $extentions       = [],
   Hash                          $default_options  = {},
+  Boolean                       $manage_python    = true,
 )
 {
   case $facts['os']['family'] {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class thumbor::params
   Optional[String]              $virtualenv_path  = undef,
   String                        $package_name     = 'thumbor',
   String                        $package_ensure   = $ensure,
-  Variant[Boolean, String]      $pip_proxyserver  = false,
+  Optional[String]              $pip_proxyserver  = undef,
   Boolean                       $ensure_user      = true,
   String                        $user             = 'thumbor',
   Boolean                       $ensure_group     = true,

--- a/metadata.json
+++ b/metadata.json
@@ -10,15 +10,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 4.0.0 < 7.0.0"
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 1.12.0 < 3.0.0"
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "data_provider": null


### PR DESCRIPTION
### New parameter $manage_python
I'd like to manage my Python installations differently (with other settings, version, etc.), so I propose a new parameter `$manage_python` to control wether the Python installation is managed or not.

This parameter defaults to `true`.

### Fix proxy settings for puppet/python
The module puppet/python does not allow `$proxy` to be set to `false`, which is currently the default value that is used by this module. I propose changing the default to `undef` and making this value optional to fix this issue. Setting it to `undef` effectively disables the proxy setting.

This fixes the following error when using recent versions of puppet/python:
```
Python::Pip[thumbor]: parameter 'proxy' expects a match for Stdlib::HTTPUrl = Pattern[/^https?:\/\//], got Boolean
```

While here, fix an occurence of the nonexistent `$thumbor::proxy` parameter by replacing it with `thumbor::pip_proxyserver`.

### Updated dependency versions
Furthermore I took the opportunity to set more accurate version requirements for all dependences.