### PR TITLE
fix systemd service handling

### DIFF
--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -7,14 +7,8 @@ define thumbor::service::systemd
 
   service { $service_name:
     enable    => true,
+    ensure    => 'running',
     require   => Systemd::Unit_file['thumbor@.service'],
     subscribe => [ Class['systemd::systemctl::daemon_reload'], File["${thumbor::apppath}/thumbor.conf"] ],
   }
-
-  exec { "start ${service_name}":
-    command     => "systemctl start ${service_name}",
-    refreshonly => true,
-    subscribe   => Service[$service_name],
-  }
 }
-


### PR DESCRIPTION
Unfortunately I missed this bug in #2 (or https://github.com/hp197/puppet-thumbor/commit/38a740b8eccc2f3f6d686768c723be6d480a2965 respectively). The `Exec` is unnessecary and actually fails the Puppet run:

```
Error: Failed to apply catalog: Validation of Exec[start thumbor@8880] failed: 
'systemctl start thumbor@8880' is not qualified and no path was specified. 
Please qualify the command or specify a path. 
(file: /etc/puppetlabs/code/environments/testing/modules/thumbor/manifests/service/systemd.pp, line: 14)
```

Removing the `Exec` and adding `ensure => 'running'` is all that's needed :)